### PR TITLE
use datastore to store comments permanently

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -25,6 +25,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.6</version>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that allows users to add comments and returns comment  */
+/** Servlet that allows users to add comments and returns comment history  */
 @WebServlet("/comments")
 public class DataServlet extends HttpServlet {
     


### PR DESCRIPTION
Commit makes use of datastore to store comments permanently when user adds them so that they can then be queried for the comments history.